### PR TITLE
Add upfront database integrity check 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,22 @@ cmake -S src -B build
 cmake --build build
 ```
 
+Run the tool you just built:
+
+```shell
+build/fsck.s3gw /path/to/s3gw/store
+```
+
+Or, build and run it in a container using Docker or Podman:
+
+```shell
+# Docker
+docker build -t fsck.s3gw .
+docker run -v /path/to/s3gw/store:/volume fsck.s3gw /volume
+
+# Podman
+podman build -t fsck.s3gw .
+podman run -v /path/to/s3gw/store:/volume fsck.s3gw /volume
+```
+
 [1]: https://s3gw.io

--- a/src/checks/metadata_schema_version.h
+++ b/src/checks/metadata_schema_version.h
@@ -52,6 +52,6 @@ class MetadataSchemaVersionCheck : public Check {
   virtual int check() override;
 };
 
-const int EXPECTED_METADATA_SCHEMA_VERSION = 1;
+const int EXPECTED_METADATA_SCHEMA_VERSION = 3;
 
 #endif  // FSCK_S3GW_SRC_CHECKS_METADATA_SCHEMA_VERSION_H__

--- a/src/main.cc
+++ b/src/main.cc
@@ -29,6 +29,7 @@
 #include <iostream>
 
 #include "checks.h"
+#include "sqlite.h"
 
 #define FSCK_ASSERT(condition, message) \
   if (!condition) {                     \
@@ -84,6 +85,10 @@ int main(int argc, char* argv[]) {
     FSCK_ASSERT(
         std::filesystem::is_regular_file(path_database),
         "Metadata database is not a regular file"
+    );
+    Database db(path_database);
+    FSCK_ASSERT(db.check_integrity(),
+        "Database integrity check failed"
     );
   }
 

--- a/src/sqlite.cc
+++ b/src/sqlite.cc
@@ -20,6 +20,8 @@
 
 #include <filesystem>
 #include <iostream>
+#include <cstring>
+#include <cassert>
 
 Database::Database(std::filesystem::path dbpath) {
   db = dbpath;
@@ -33,6 +35,34 @@ Database::Database(std::filesystem::path dbpath) {
 
 Database::~Database() {
   sqlite3_close(handle);
+}
+
+bool Database::check_integrity() {
+
+  auto callback = [](void * arg, int num_columns, char ** column_data, char **) {
+    assert(num_columns == 1);
+    if (std::strcmp(column_data[0], "ok") == 0) {
+      *(static_cast<bool *>(arg)) = true;
+    } else {
+      std::cout << column_data[0] << std::endl;
+    }
+    return 0;
+  };
+
+  bool is_ok = false;
+  // This will return up to 100 error rows by default.  For more details see
+  // https://www.sqlite.org/pragma.html#pragma_integrity_check
+  int rc = sqlite3_exec(handle, "PRAGMA integrity_check",
+    callback, static_cast<void *>(&is_ok), NULL);
+  if (rc != SQLITE_OK) {
+    // This will happen if the file is _so_ trashed it doesn't even
+    // look like an SQLite database.  Here you'll see things like:
+    // - file is not a database (26)
+    // - database disk image is malformed (11)
+    std::cout << "sqlite3_exec error: " << sqlite3_errstr(rc) << " (" << rc << ")" << std::endl;
+  }
+
+  return is_ok;
 }
 
 int Database::prepare(std::string query, sqlite3_stmt** stm) {

--- a/src/sqlite.h
+++ b/src/sqlite.h
@@ -36,6 +36,8 @@ class Database {
   Database(std::filesystem::path);
   ~Database();
 
+  bool check_integrity();
+
   int prepare(std::string, sqlite3_stmt**);
 
   int count_in_table(std::string, std::string);


### PR DESCRIPTION
If the SQLite database is itself corrupt, there's little point checking
the files on the disk, because we have no metadata to check them against.
So this is a special check that happens right at the start before all
other checks.

If the file is _so_ trashed it doesn't even look like an SQLite database
then `PRAGMA integrity_check` will return immediately with an error and
you'll see something like `sqlite3_exec error: file is not a database (26)`
or `sqlite3_exec error: database disk image is malformed (11)`.

If the file isn't too badly damaged (in my test I chopped 1KB off the end),
the integrity check will actually run, and you'll see potentially several
lines of output, e.g.:

```
*** in database main ***
Fragmentation of 206 bytes reported as 0 on page 28
row 1 missing from index versioned_object_objid_vid_unique
row 2 missing from index versioned_object_objid_vid_unique
row 3 missing from index versioned_object_objid_vid_unique
```

This PR also updates the README and bumps the expected metadata schema to version 3