### PR TITLE
OrphanedObjects: detect object vs. multipart vs. unexpected file

### DIFF
--- a/src/checks/orphaned_objects.h
+++ b/src/checks/orphaned_objects.h
@@ -46,6 +46,19 @@ class OrphanedObjectsFix : public Fix {
   void fix();
 };
 
+class UnexpectedFileFix : public Fix {
+ private:
+  std::filesystem::path root_path;
+  std::filesystem::path obj_path;  // relative to root_path
+
+  std::string to_string() const;
+
+ public:
+  UnexpectedFileFix(std::filesystem::path, std::filesystem::path);
+  operator std::string() const { return to_string(); };
+  void fix();
+};
+
 class OrphanedObjectsCheck : public Check {
  private:
   std::filesystem::path root_path;


### PR DESCRIPTION
This expands OrphanedObjectsCheck::check() to understand different types of file, based on what their filenames look like.  The rules here are:

- If the filename is an integer number (i.e. matches "^[0-9]+$") then it's assumed to be a versioned object, and the concatenation of its parent directories provides the object UUID.
- If the filename looks like most of a UUID, but with a dash and an integer stuck on the end, it's part of a multipart upload.
- If the filename doesn't match one of the above, it shouldn't be there at all.

The current implementation doesn't explicitly check that parent directories are sane given the file type, but if (for example) an integer-looking-filename (assumed versioned object) appears at the wrong level in the directory hierarchy, it will still be reported as an orphaned object because the UUID obtained from path concatenation won't match anything in the database.